### PR TITLE
Add support for reading params as URL-encoded JSON from the URL fragment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,22 @@ var getAppender = require('./log/getAppender.js');
 var logger      = require('./log/logger.js');
 var eventListener = require('eventlistener');
 var childrenSize  = require('./childrensize.js');
+var extend        = require('util-extend');
+
+function readParams () {
+    // Params are passed as a JSON in the url fragment by default. IE has a limit for URLs longer than 2083 bytes, so
+    // fallback to iframe.name if there is no url fragment.
+    // We can't only rely on iframe.name because WebViews from native apps don't use an iframe, and it's currently no
+    // easy way to define window.name synchronously before the document is loaded on iOS.
+    var urlFragment = decodeURIComponent(document.location.hash.substring(1));
+    return JSON.parse(urlFragment || window.name);
+}
 
 var bootStrap = function () {
     var gardr = global.gardr || {};
     if (!global.gardr) { global.gardr = gardr; }
 
-    gardr.params = gardr.params || JSON.parse(window.name);
+    gardr.params = extend(gardr.params || {}, readParams());
     gardr.id = gardr.params.id;
     gardr.log = logger.create(gardr.id, gardr.params.loglevel, getAppender(gardr.params.logto));
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,8 +12,16 @@ var defaultParams = {
     origin: 'http://gardr.github.io'
 };
 
-function setNameData (data) {
-    window.name = JSON.stringify(extend(extend({}, defaultParams), data));
+function paramsStr (data) {
+    return JSON.stringify(extend(extend({}, defaultParams), data));
+}
+
+function setUrlFragment (data) {
+    document.location.hash = '#'+encodeURIComponent(paramsStr(data));
+}
+
+function setName (data) {
+    window.name = paramsStr(data);
 }
 
 function triggerOnLoad () {
@@ -43,13 +51,14 @@ describe('Garðr ext - bootStrap', function () {
             return com;
         });
         bootStrap._setComClient(comClient);
-        setNameData();
+        setUrlFragment();
     });
 
     afterEach(function () {
         delete window.gardr;
         document.write = orgWrite;
         window.name = null;
+        document.location.hash = '#';
     });
 
     it('should define ‘gardr’ in global scope', function () {
@@ -58,8 +67,20 @@ describe('Garðr ext - bootStrap', function () {
         expect(window.gardr).to.exist;
     });
 
-    it('should read parameters from location.href by default', function () {
-        setNameData({url: 'http://gardr.github.io/ad|123'});
+    it('should read parameters from location.hash', function () {
+        setUrlFragment({url: 'http://gardr.github.io/ad|123'});
+        bootStrap();
+
+        expect(gardr.params).to.exist;
+        expect(gardr.id).to.equal('pos-id');
+        expect(gardr.params.origin).to.equal('http://gardr.github.io');
+        expect(gardr.params.url).to.equal('http://gardr.github.io/ad|123');
+        expect(gardr.params.timeout).to.equal(200);
+    });
+
+    it('should read parameters from window.name', function () {
+        document.location.hash = '#';
+        setName({url: 'http://gardr.github.io/ad|123'});
         bootStrap();
 
         expect(gardr.params).to.exist;
@@ -70,7 +91,7 @@ describe('Garðr ext - bootStrap', function () {
     });
 
     it('should log to div by default', function () {
-        setNameData({loglevel: 4});
+        setUrlFragment({loglevel: 4});
         bootStrap();
         gardr.log.debug('test');
         var logDiv = document.getElementById('logoutput');
@@ -85,7 +106,7 @@ describe('Garðr ext - bootStrap', function () {
 
     it('should document.write a script tag with src equal to the input url', function() {
         var scriptUrl = 'http://external.com/script.js?q=1';
-        setNameData({url: scriptUrl});
+        setUrlFragment({url: scriptUrl});
         bootStrap();
 
         document.write.should.have.been.calledWithMatch(function (value) {


### PR DESCRIPTION
Using iframe.name to pass data works well on the web, but not from apps. They use WebViews instead of iframes, and it's hard or not possible to define the name variable synchronously from the app-code. URLs are easier to debug both for apps and web, but using query-parameters are limiting if we want a “scope” for each plugin to pass parameters to the ext frame. So using a JSON in the URL is the best of both, but IE has a max URL-length of 2083 characters, so on the web we should fallback to using iframe.name if the URL-length is too long.
