### PR TITLE
Replace GARDR_UNIQUE_ID in the url with timestamp + id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var getAppender = require('./log/getAppender.js');
 var logger      = require('./log/logger.js');
 var eventListener = require('eventlistener');
 var childrenSize  = require('./childrensize.js');
+var UNIQUE_TOKEN_REGEX = /(GARDR|PASTIES)_UNIQUE_ID/;
 
 function readParams () {
     // Params are passed as a JSON in the url fragment by default. IE has a limit for URLs longer than 2083 bytes, so
@@ -12,6 +13,15 @@ function readParams () {
     // easy way to define window.name synchronously before the document is loaded on iOS.
     var urlFragment = decodeURIComponent(document.location.hash.substring(1));
     return JSON.parse(urlFragment || window.name);
+}
+
+function replaceUniqueToken (url, id) {
+    // We cannot use a global regex because of this bug:
+    // // http://stackoverflow.com/questions/3827456/what-is-wrong-with-my-date-regex/3827500#3827500
+    while (url && UNIQUE_TOKEN_REGEX.test(url)) {
+        url = url.replace(UNIQUE_TOKEN_REGEX, '' + new Date().getTime() + (id));
+    }
+    return url;
 }
 
 var bootStrap = function () {
@@ -24,6 +34,8 @@ var bootStrap = function () {
     gardr.log = logger.create(gardr.id, gardr.params.loglevel, getAppender(gardr.params.logto));
 
     // TODO requestAnimationFrame polyfill
+
+    gardr.params.url = replaceUniqueToken(gardr.params.url, gardr.id);
 
     gardr.log.debug('Loading url: ' + gardr.params.url);
     document.write('<span id="gardr">');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -114,6 +114,24 @@ describe('Garðr ext - bootStrap', function () {
         });
     });
 
+    it('should replace GARDR_UNIQUE_ID in the url with timestamp + id', function() {
+        var scriptUrl = 'http://external.com/script.js?q=1&m=GARDR_UNIQUE_ID&m2=GARDR_UNIQUE_ID';
+        setUrlFragment({url: scriptUrl});
+        var now = new Date().getTime();
+        var clock = sinon.useFakeTimers(now);
+        bootStrap();
+        clock.restore();
+
+        document.write.should.have.been.calledWithMatch(function (value) {
+            if (value.indexOf('<scri') !== 0) { return false; }
+            var tmp = document.createElement('div');
+            tmp.innerHTML=value;
+            var src = tmp.firstElementChild.src;
+            var unique = src.substring(src.lastIndexOf('=')+1);
+            return value.indexOf('GARDR_UNIQUE_ID') == -1 && unique == '' + now + gardr.id;
+        });
+    });
+
     it('should trigger comClient.rendered when all resources are loaded', function () {
         bootStrap();
 


### PR DESCRIPTION
We have been replacing GARDR_UNIQUE_ID with something unique (timestamp + id) in gardr/host, but this is also needed for native apps, which only use gardr/ext. So we need to implement this in ext and remove it from host.
