### PR TITLE
Improper calculated size of rendered elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 .DS_Store
 .tern-port
 *.sublime-workspace
+*.swp
 dist

--- a/lib/childrensize.js
+++ b/lib/childrensize.js
@@ -1,15 +1,24 @@
 var computedStyle = require('computed-style');
 
-function toArray (nodeList) {
+function toFlatArray (nodeList) {
     var arr = [];
-    for (var i=0, l=nodeList.length; i<l; i++) { arr.push(nodeList[i]); }
+    var i;
+    var l;
+
+    for (i = 0, l = nodeList.length; i < l; i++) {
+        arr.push(nodeList[i]);
+        if (nodeList[i].children.length > 0) {
+            arr = arr.concat(toFlatArray(nodeList[i].children));
+        }
+    }
+
     return arr;
 }
 
 module.exports = function(container) {
     if (!container) { return; }
 
-    var children = toArray(container.children).filter(function (el) {
+    var children = toFlatArray(container.children).filter(function (el) {
         var pos = computedStyle(el, 'position');
         el.rect = el.getBoundingClientRect(); // store rect for later
         return !(

--- a/test/childrensize.test.js
+++ b/test/childrensize.test.js
@@ -49,6 +49,22 @@ describe('childrenSize', function () {
         expect(res.height).to.equal(10, 'height');
     });
 
+    it('should return total with and height for nested children', function () {
+        var parent = createDiv('100%');
+        var a = createElement('a', '10px', '10px');
+        var img = createElement('img', '30px', '50px');
+
+        img.style.verticalAlign = 'bottom';
+        a.appendChild(img);
+        parent.appendChild(a);
+        document.body.appendChild(parent);
+
+        var res = childrenSize(parent);
+        expect(res).to.exist;
+        expect(res.width).to.equal(30, 'width');
+        expect(res.height).to.equal(50, 'height');
+    });
+
     it('should ignore children with position absolute/fixed', function () {
         insertCss('#absolute-position { position: absolute; display: inline-block; }');
         insertCss('#fixed-position { position: fixed; display: inline-block; }');


### PR DESCRIPTION
Sometimes dimensions returned in item.rendered property are incorrect. This is probably because childrenSize lib goes only one element deep into the tree.

Live example: http://jsfiddle.net/d1vyyvnr/

Refresh it a couple of times (ads are randomized) - sometimes height is calculated to 17px, while visually it's clearly more than that.

Env: Chrome 37.0.2062.120 on Windows 7
