### PR TITLE
Fix for iOS Safari bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,9 +70,10 @@ var bootStrap = function (options) {
 
     gardr.log.debug('Loading url: ' + gardr.params.url);
 
-    document.write(['<span id="gardr"><scr', 'ipt src="', gardr.params.url, '" ></scr', 'ipt></span>'].join(''));
+    document.write(['<div id="gardr"><scr', 'ipt src="', gardr.params.url, '" ></scr', 'ipt></div>'].join(''));
 
     gardr.container = document.getElementById('gardr');
+    gardr.container.style.overflow = 'hidden'; // avoid iOS Safari bug http://stackoverflow.com/q/6721310
     pluginApi.trigger('element:containercreated', gardr.container);
 
     var com = comClient(gardr.id, window.parent, gardr.params.origin);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,7 +145,18 @@ describe('Garðr ext - gardrExt', function () {
 
     it('should document.write out a gardr container to the document', function () {
         gardrExt(extOpts);
-        document.write.should.have.been.calledWithMatch(/<span id="gardr"><scr.pt src=".*"\s*><\/scr.pt><\/span>/);
+        document.write.should.have.been.calledWithMatch(/<div id="gardr"><scr.pt src=".*"\s*><\/scr.pt><\/div>/);
+    });
+
+    it('should assign the gardr container to gardr.container', function () {
+        gardrExt(extOpts);
+        expect(gardr.container).to.exist;
+        expect(gardr.container.id).to.equal('gardr');
+    }),
+
+    it('should set overflow:hidden on the gardr container', function () {
+        gardrExt(extOpts);
+        expect(gardr.container.style.overflow).to.equal('hidden');
     });
 
     it('should document.write a script tag with src equal to the input url', function() {


### PR DESCRIPTION
Fix for issue #10

Change the container to a div (block element) and add `overflow:hidden`, so Safari calculates the correct size and does not resize the iframe element on the host side.

See issue #10 and gardr/host#8 for more info.